### PR TITLE
Reload command and IP -> FQDN recognition support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.14.4-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.5-R0.1-SNAPSHOT</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </properties>
 
     <build>
-        <finalName>${project.name}</finalName>
+        <finalName>${project.name}-${project.version}</finalName>
         <sourceDirectory>src/main/java</sourceDirectory>
         <resources>
             <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,30 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>org.bstats</pattern>
+              <shadedPattern>me.lucko.networkinterceptor.bstats</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+        </plugins>
     </build>
 
     <dependencies>
@@ -40,6 +64,12 @@
             <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>2.2.1</version>
+            <scope>compile</scope>
+          </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.lucko</groupId>
     <artifactId>networkinterceptor</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>NetworkInterceptor</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.lucko</groupId>
     <artifactId>networkinterceptor</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>NetworkInterceptor</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.lucko</groupId>
     <artifactId>networkinterceptor</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>NetworkInterceptor</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.lucko</groupId>
     <artifactId>networkinterceptor</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>NetworkInterceptor</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
 
     <name>NetworkInterceptor</name>
 
+    <description>Plugin to monitor and block outgoing network requests</description>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -33,9 +35,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/lucko/networkinterceptor/InterceptEvent.java
+++ b/src/main/java/me/lucko/networkinterceptor/InterceptEvent.java
@@ -1,12 +1,20 @@
 package me.lucko.networkinterceptor;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
 public class InterceptEvent {
     private final String host;
     private final StackTraceElement[] stackTrace;
+    private final Map<StackTraceElement, JavaPlugin> nonInternalStackTrace = new HashMap<>();
 
     public InterceptEvent(String host, StackTraceElement[] stackTrace) {
         this.host = host;
         this.stackTrace = stackTrace;
+        generateNonInternalStackTrace();
     }
 
     public String getHost() {
@@ -15,5 +23,41 @@ public class InterceptEvent {
 
     public StackTraceElement[] getStackTrace() {
         return this.stackTrace;
+    }
+
+    public Map<StackTraceElement, JavaPlugin> getNonInternalStackTraceWithPlugins() {
+        return Collections.unmodifiableMap(nonInternalStackTrace);
+    }
+
+    private void generateNonInternalStackTrace() {
+        boolean shouldPrint = false;
+        for (StackTraceElement element : stackTrace) {
+            if (!shouldPrint) {
+                boolean isInternal = element.getClassName().startsWith("me.lucko.networkinterceptor")
+                        || element.getClassName().startsWith("java.net")
+                        || element.getClassName().startsWith("java.security")
+                        || element.getClassName().startsWith("sun.net")
+                        || element.getClassName().startsWith("sun.security.ssl");
+
+                if (!isInternal) {
+                    shouldPrint = true;
+                }
+            }
+
+            if (shouldPrint) {
+                // sb.append("\tat ").append(element);
+                JavaPlugin providingPlugin;
+                try {
+                    // append the name of the plugin
+                    Class<?> clazz = Class.forName(element.getClassName());
+                    providingPlugin = JavaPlugin.getProvidingPlugin(clazz);
+                    // sb.append(" [").append(providingPlugin.getName()).append(']');
+                } catch (Exception e) {
+                    // ignore
+                    providingPlugin = null;
+                }
+                nonInternalStackTrace.put(element, providingPlugin);
+            }
+        }
     }
 }

--- a/src/main/java/me/lucko/networkinterceptor/InterceptEvent.java
+++ b/src/main/java/me/lucko/networkinterceptor/InterceptEvent.java
@@ -10,6 +10,7 @@ public class InterceptEvent {
     private final String host;
     private final StackTraceElement[] stackTrace;
     private final Map<StackTraceElement, JavaPlugin> nonInternalStackTrace = new LinkedHashMap<>();
+    private String originalHost;
 
     public InterceptEvent(String host, StackTraceElement[] stackTrace) {
         this.host = host;
@@ -60,4 +61,13 @@ public class InterceptEvent {
             }
         }
     }
+
+    public void setOriginalHost(String host) {
+        this.originalHost = host;
+    }
+
+    public String getOriginalHost() {
+        return originalHost;
+    }
+
 }

--- a/src/main/java/me/lucko/networkinterceptor/InterceptEvent.java
+++ b/src/main/java/me/lucko/networkinterceptor/InterceptEvent.java
@@ -1,7 +1,7 @@
 package me.lucko.networkinterceptor;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.bukkit.plugin.java.JavaPlugin;
@@ -9,7 +9,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class InterceptEvent {
     private final String host;
     private final StackTraceElement[] stackTrace;
-    private final Map<StackTraceElement, JavaPlugin> nonInternalStackTrace = new HashMap<>();
+    private final Map<StackTraceElement, JavaPlugin> nonInternalStackTrace = new LinkedHashMap<>();
 
     public InterceptEvent(String host, StackTraceElement[] stackTrace) {
         this.host = host;

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
@@ -106,6 +106,7 @@ public class NetworkInterceptor extends JavaPlugin {
                 getLogger().log(Level.SEVERE, "Exception occurred whilst disabling " + interceptor.getClass().getName(), e);
             }
         }
+        this.interceptors.clear();
     }
 
     private void setupInterceptors(FileConfiguration configuration) {

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
@@ -201,7 +201,8 @@ public class NetworkInterceptor extends JavaPlugin {
         // TODO - add configurable config empty
         if (blocker != null && configuration.getBoolean("learning.enabled", true)) {
             getLogger().warning("Using Learning blocker!");
-            blocker = new LearningBlocker(this, blocker);
+            long similarStackTimeoutMs = configuration.getLong("learning.similar-stack-timeout-ms", 100L);
+            blocker = new LearningBlocker(this, blocker, similarStackTimeoutMs);
         }
     }
 

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
@@ -118,6 +118,9 @@ public class NetworkInterceptor extends JavaPlugin {
             }
         }
         this.interceptors.clear();
+        if (blocker instanceof LearningBlocker) {
+            ((LearningBlocker) blocker).cancelCleanup();
+        }
     }
 
     private void setupInterceptors(FileConfiguration configuration) {

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
@@ -10,8 +10,8 @@ import me.lucko.networkinterceptor.interceptors.ProxySelectorInterceptor;
 import me.lucko.networkinterceptor.interceptors.SecurityManagerInterceptor;
 import me.lucko.networkinterceptor.loggers.CompositeLogger;
 import me.lucko.networkinterceptor.loggers.ConsoleLogger;
-import me.lucko.networkinterceptor.loggers.FileLogger;
 import me.lucko.networkinterceptor.loggers.EventLogger;
+import me.lucko.networkinterceptor.loggers.FileLogger;
 
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -93,7 +93,7 @@ public class NetworkInterceptor extends JavaPlugin {
             try {
                 interceptor.enable();
             } catch (Exception e) {
-                getLogger().log(Level.SEVERE,"Exception occurred whilst enabling " + interceptor.getClass().getName(), e);
+                getLogger().log(Level.SEVERE, "Exception occurred whilst enabling " + interceptor.getClass().getName(), e);
             }
         }
     }
@@ -103,7 +103,7 @@ public class NetworkInterceptor extends JavaPlugin {
             try {
                 interceptor.disable();
             } catch (Exception e) {
-                getLogger().log(Level.SEVERE,"Exception occurred whilst disabling " + interceptor.getClass().getName(), e);
+                getLogger().log(Level.SEVERE, "Exception occurred whilst disabling " + interceptor.getClass().getName(), e);
             }
         }
     }
@@ -132,7 +132,7 @@ public class NetworkInterceptor extends JavaPlugin {
                 Interceptor interceptor = constructor.newInstance(this);
                 this.interceptors.put(method, interceptor);
             } catch (Throwable t) {
-                getLogger().log(Level.SEVERE,"Exception occurred whilst initialising method " + method, t);
+                getLogger().log(Level.SEVERE, "Exception occurred whilst initialising method " + method, t);
             }
         }
     }

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
@@ -202,9 +202,9 @@ public class NetworkInterceptor extends JavaPlugin {
                 getLogger().severe("Unknown blocking mode: " + mode);
         }
         // TODO - add configurable config empty
-        if (blocker != null && configuration.getBoolean("learning.enabled", true)) {
+        if (blocker != null && configuration.getBoolean("mapping.enabled", true)) {
             getLogger().info("Using a mapping blocker");
-            long similarStackTimeoutMs = configuration.getLong("learning.similar-stack-timeout-ms", 100L);
+            long similarStackTimeoutMs = configuration.getLong("mapping.timer", 100L);
             blocker = new LearningBlocker(this, blocker, similarStackTimeoutMs);
         }
     }

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 
 import me.lucko.networkinterceptor.blockers.BlacklistBlocker;
 import me.lucko.networkinterceptor.blockers.Blocker;
+import me.lucko.networkinterceptor.blockers.LearningBlocker;
 import me.lucko.networkinterceptor.blockers.WhitelistBlocker;
 import me.lucko.networkinterceptor.interceptors.Interceptor;
 import me.lucko.networkinterceptor.interceptors.ProxySelectorInterceptor;
@@ -50,6 +51,9 @@ public class NetworkInterceptor extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        if (blocker instanceof LearningBlocker) {
+            ((LearningBlocker) blocker).scheduleCleanup();
+        }
         getCommand("networkinterceptor").setExecutor(new NetworkInterceptorCommand(this));
     }
 
@@ -193,6 +197,11 @@ public class NetworkInterceptor extends JavaPlugin {
                 break;
             default:
                 getLogger().severe("Unknown blocking mode: " + mode);
+        }
+        // TODO - add configurable config empty
+        if (blocker != null && configuration.getBoolean("learning.enabled", true)) {
+            getLogger().warning("Using Learning blocker!");
+            blocker = new LearningBlocker(this, blocker);
         }
     }
 

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
@@ -13,6 +13,7 @@ import me.lucko.networkinterceptor.loggers.ConsoleLogger;
 import me.lucko.networkinterceptor.loggers.EventLogger;
 import me.lucko.networkinterceptor.loggers.FileLogger;
 
+import org.bstats.bukkit.Metrics;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -39,6 +40,12 @@ public class NetworkInterceptor extends JavaPlugin {
         saveDefaultConfig();
 
         enable();
+
+        // check and enable bStats
+        if (getConfig().getBoolean("bstats-enable", false)) {
+            int pluginId = -1; // <-- Replace with the id of your plugin!
+            new Metrics(this, pluginId);
+        }
     }
 
     @Override

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptor.java
@@ -203,7 +203,7 @@ public class NetworkInterceptor extends JavaPlugin {
         }
         // TODO - add configurable config empty
         if (blocker != null && configuration.getBoolean("learning.enabled", true)) {
-            getLogger().warning("Using Learning blocker!");
+            getLogger().info("Using a mapping blocker");
             long similarStackTimeoutMs = configuration.getLong("learning.similar-stack-timeout-ms", 100L);
             blocker = new LearningBlocker(this, blocker, similarStackTimeoutMs);
         }

--- a/src/main/java/me/lucko/networkinterceptor/NetworkInterceptorCommand.java
+++ b/src/main/java/me/lucko/networkinterceptor/NetworkInterceptorCommand.java
@@ -1,0 +1,50 @@
+package me.lucko.networkinterceptor;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.util.StringUtil;
+
+import java.util.Collections;
+import java.util.List;
+
+public class NetworkInterceptorCommand implements TabExecutor {
+
+    private final NetworkInterceptor plugin;
+
+    public NetworkInterceptorCommand(NetworkInterceptor plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage(ChatColor.RED + "Running NetworkInterceptor v" + this.plugin.getDescription().getVersion());
+            sender.sendMessage(ChatColor.GRAY + "Use '/networkinterceptor reload' to reload the configuration.");
+
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("reload") && sender.hasPermission("networkinterceptor.reload")) {
+            this.plugin.reload();
+
+            sender.sendMessage(ChatColor.GOLD + "NetworkInterceptor configuration reloaded.");
+
+            return true;
+        }
+
+        sender.sendMessage(ChatColor.RED + "Unknown subcommand.");
+
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1 && StringUtil.startsWithIgnoreCase("reload", args[0])) {
+            return Collections.singletonList("reload");
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
+++ b/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
@@ -9,15 +9,16 @@ import org.bukkit.plugin.java.JavaPlugin;
 import me.lucko.networkinterceptor.InterceptEvent;
 
 public class LearningBlocker implements Blocker {
-    private static final long STACK_CHECK_TIMEOUT_MS = 100L; // TODO - configurable
     private static final long STACK_TIMEOUT_CLEAR_DELAY = 70 * 1000L; // TODO - configurable
+    private final long similarStackTimeoutMs;
     private final JavaPlugin plugin;
     private final Blocker delegate;
     private final Map<StackTraces, StackTraces> cachedAllowedTraces = new HashMap<>();
 
-    public LearningBlocker(JavaPlugin plugin, Blocker delegate) {
+    public LearningBlocker(JavaPlugin plugin, Blocker delegate, long similarStackTimeoutMs) {
         this.plugin = plugin;
         this.delegate = delegate;
+        this.similarStackTimeoutMs = similarStackTimeoutMs;
     }
 
     public void scheduleCleanup() {
@@ -36,7 +37,7 @@ public class LearningBlocker implements Blocker {
         }
         // not allowed by default
         StackTraces prev = cachedAllowedTraces.get(traces);
-        long lastAllowed = System.currentTimeMillis() - STACK_CHECK_TIMEOUT_MS;
+        long lastAllowed = System.currentTimeMillis() - similarStackTimeoutMs;
         if (prev != null && prev.stamp >= lastAllowed) { // TODO - configurable ?
             // similar trace has been allowed in the past
             event.setOriginalHost(prev.originalHost);
@@ -46,7 +47,7 @@ public class LearningBlocker implements Blocker {
     }
 
     private void cleanOldTraces() {
-        long oldestStamp = System.currentTimeMillis() - STACK_CHECK_TIMEOUT_MS;
+        long oldestStamp = System.currentTimeMillis() - similarStackTimeoutMs;
         cachedAllowedTraces.values().removeIf(val -> val.stamp < oldestStamp);
     }
 

--- a/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
+++ b/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
 import me.lucko.networkinterceptor.InterceptEvent;
 
@@ -14,6 +15,7 @@ public class LearningBlocker implements Blocker {
     private final JavaPlugin plugin;
     private final Blocker delegate;
     private final Map<StackTraces, StackTraces> cachedAllowedTraces = new HashMap<>();
+    private BukkitTask cleanupTask;
 
     public LearningBlocker(JavaPlugin plugin, Blocker delegate, long similarStackTimeoutMs) {
         this.plugin = plugin;
@@ -21,8 +23,15 @@ public class LearningBlocker implements Blocker {
         this.similarStackTimeoutMs = similarStackTimeoutMs;
     }
 
+    public void cancelCleanup() {
+        if (cleanupTask != null) {
+            cleanupTask.cancel();
+        }
+    }
+
     public void scheduleCleanup() {
-        plugin.getServer().getScheduler().runTaskTimerAsynchronously(plugin, this::cleanOldTraces,
+        cancelCleanup();
+        cleanupTask = plugin.getServer().getScheduler().runTaskTimerAsynchronously(plugin, this::cleanOldTraces,
                 STACK_TIMEOUT_CLEAR_DELAY, STACK_TIMEOUT_CLEAR_DELAY);
     }
 

--- a/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
+++ b/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
@@ -39,8 +39,6 @@ public class LearningBlocker implements Blocker {
         long lastAllowed = System.currentTimeMillis() - STACK_CHECK_TIMEOUT_MS;
         if (prev != null && prev.stamp >= lastAllowed) { // TODO - configurable ?
             // similar trace has been allowed in the past
-            plugin.getLogger().info("Allowing because of similar trace! ['" + event.getHost()
-                    + "' was found to correspond to '" + prev.originalHost + "']");
             event.setOriginalHost(prev.originalHost);
             return false; // allow
         }

--- a/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
+++ b/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
@@ -1,0 +1,82 @@
+package me.lucko.networkinterceptor.blockers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import me.lucko.networkinterceptor.InterceptEvent;
+
+public class LearningBlocker implements Blocker {
+    private static final long STACK_CHECK_TIMEOUT_MS = 10L; // TODO - configurable
+    private static final long STACK_TIMEOUT_CLEAR_DELAY = 70 * 1000L; // TODO - configurable
+    private final JavaPlugin plugin;
+    private final Blocker delegate;
+    private final Map<StackTraces, StackTraces> cachedAllowedTraces = new HashMap<>();
+
+    public LearningBlocker(JavaPlugin plugin, Blocker delegate) {
+        this.plugin = plugin;
+        this.delegate = delegate;
+    }
+
+    public void scheduleCleanup() {
+        plugin.getServer().getScheduler().runTaskTimerAsynchronously(plugin, this::cleanOldTraces,
+                STACK_TIMEOUT_CLEAR_DELAY, STACK_TIMEOUT_CLEAR_DELAY);
+    }
+
+    @Override
+    public boolean shouldBlock(InterceptEvent event) {
+        boolean rawBlock = delegate.shouldBlock(event);
+        // unmodifiable map
+        StackTraces traces = new StackTraces(event.getNonInternalStackTraceWithPlugins(), event.getHost());
+        if (!rawBlock) { // allowed by default -> allow
+            cachedAllowedTraces.put(traces, traces);
+            return rawBlock; // allow
+        }
+        // not allowed by default
+        StackTraces prev = cachedAllowedTraces.get(traces);
+        if (prev != null) { // TODO - configurable ?
+            // similar trace has been allowed in the past
+            plugin.getLogger().info("Allowing because of similar trace! ['" + event.getHost()
+                    + "' was found to correspond to '" + prev.originalHost + "']");
+            return false; // allow
+        }
+        return rawBlock; // block
+    }
+
+    private void cleanOldTraces() {
+        long oldestStamp = System.currentTimeMillis() - STACK_CHECK_TIMEOUT_MS;
+        cachedAllowedTraces.values().removeIf(val -> val.stamp < oldestStamp);
+    }
+
+    private class StackTraces {
+        private final Map<StackTraceElement, JavaPlugin> payload;
+        private final String originalHost;
+        private final long stamp = System.currentTimeMillis();
+
+        private StackTraces(Map<StackTraceElement, JavaPlugin> payload, String originalHost) {
+            this.payload = payload;
+            this.originalHost = originalHost;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(payload); // original host not included
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof StackTraces)) {
+                return false;
+            }
+            StackTraces o = (StackTraces) other;
+            return payload.equals(o.payload); // original host not included
+        }
+
+    }
+
+}

--- a/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
+++ b/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
@@ -9,7 +9,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import me.lucko.networkinterceptor.InterceptEvent;
 
 public class LearningBlocker implements Blocker {
-    private static final long STACK_CHECK_TIMEOUT_MS = 10L; // TODO - configurable
+    private static final long STACK_CHECK_TIMEOUT_MS = 100L; // TODO - configurable
     private static final long STACK_TIMEOUT_CLEAR_DELAY = 70 * 1000L; // TODO - configurable
     private final JavaPlugin plugin;
     private final Blocker delegate;
@@ -36,7 +36,8 @@ public class LearningBlocker implements Blocker {
         }
         // not allowed by default
         StackTraces prev = cachedAllowedTraces.get(traces);
-        if (prev != null) { // TODO - configurable ?
+        long lastAllowed = System.currentTimeMillis() - STACK_CHECK_TIMEOUT_MS;
+        if (prev != null && prev.stamp >= lastAllowed) { // TODO - configurable ?
             // similar trace has been allowed in the past
             plugin.getLogger().info("Allowing because of similar trace! ['" + event.getHost()
                     + "' was found to correspond to '" + prev.originalHost + "']");

--- a/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
+++ b/src/main/java/me/lucko/networkinterceptor/blockers/LearningBlocker.java
@@ -40,6 +40,7 @@ public class LearningBlocker implements Blocker {
             // similar trace has been allowed in the past
             plugin.getLogger().info("Allowing because of similar trace! ['" + event.getHost()
                     + "' was found to correspond to '" + prev.originalHost + "']");
+            event.setOriginalHost(prev.originalHost);
             return false; // allow
         }
         return rawBlock; // block

--- a/src/main/java/me/lucko/networkinterceptor/interceptors/ProxySelectorInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/interceptors/ProxySelectorInterceptor.java
@@ -53,9 +53,11 @@ public class ProxySelectorInterceptor implements Interceptor {
             StackTraceElement[] trace = new Exception().getStackTrace();
             InterceptEvent event = new InterceptEvent(host, trace);
 
+            boolean blocked = ProxySelectorInterceptor.this.plugin.shouldBlock(event);
+
             ProxySelectorInterceptor.this.plugin.logAttempt(event);
 
-            if (ProxySelectorInterceptor.this.plugin.shouldBlock(event)) {
+            if (blocked) {
                 ProxySelectorInterceptor.this.plugin.logBlock(event);
                 SneakyThrow.sneakyThrow(new SocketTimeoutException("Connection timed out"));
                 throw new AssertionError();

--- a/src/main/java/me/lucko/networkinterceptor/interceptors/SecurityManagerInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/interceptors/SecurityManagerInterceptor.java
@@ -10,6 +10,8 @@ import java.security.Permission;
 public class SecurityManagerInterceptor extends SecurityManager implements Interceptor {
     private final NetworkInterceptor plugin;
 
+    private boolean enabled = true;
+
     public SecurityManagerInterceptor(NetworkInterceptor plugin) {
         this.plugin = plugin;
     }
@@ -17,6 +19,13 @@ public class SecurityManagerInterceptor extends SecurityManager implements Inter
     @Override
     public void enable() {
         System.setSecurityManager(this);
+    }
+
+    @Override
+    public void disable() {
+        enabled = false;
+
+        System.setSecurityManager(null);
     }
 
     @Override
@@ -44,7 +53,8 @@ public class SecurityManagerInterceptor extends SecurityManager implements Inter
         if (name == null) {
             return;
         }
-        if (name.equals("setSecurityManager")) {
+
+        if (this.enabled && name.equals("setSecurityManager")) {
             throw new SecurityException("Cannot replace the security manager.");
         }
     }

--- a/src/main/java/me/lucko/networkinterceptor/interceptors/SecurityManagerInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/interceptors/SecurityManagerInterceptor.java
@@ -33,9 +33,11 @@ public class SecurityManagerInterceptor extends SecurityManager implements Inter
         StackTraceElement[] trace = new Exception().getStackTrace();
         InterceptEvent event = new InterceptEvent(host, trace);
 
+        boolean blocked = this.plugin.shouldBlock(event);
+
         this.plugin.logAttempt(event);
 
-        if (this.plugin.shouldBlock(event)) {
+        if (blocked) {
             this.plugin.logBlock(event);
             SneakyThrow.sneakyThrow(new SocketTimeoutException("Connection timed out"));
             throw new AssertionError();

--- a/src/main/java/me/lucko/networkinterceptor/interceptors/SecurityManagerInterceptor.java
+++ b/src/main/java/me/lucko/networkinterceptor/interceptors/SecurityManagerInterceptor.java
@@ -4,7 +4,6 @@ import me.lucko.networkinterceptor.InterceptEvent;
 import me.lucko.networkinterceptor.NetworkInterceptor;
 import me.lucko.networkinterceptor.utils.SneakyThrow;
 
-import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.security.Permission;
 

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -22,7 +22,8 @@ public abstract class AbstractEventLogger implements EventLogger {
 
         StringBuilder sb = new StringBuilder("Intercepted outgoing connection to host ").append(host);
         String origHost = event.getOriginalHost();
-        if (origHost != null) {
+        if (origHost != null) { // original host not available since this is logged before eligibility is
+                                // checked
             sb.append(" (").append(origHost).append(")");
         }
         sb.append("\n");

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -20,7 +20,7 @@ public abstract class AbstractEventLogger implements EventLogger {
     public void logAttempt(InterceptEvent event) {
         String host = event.getHost();
 
-        StringBuilder sb = new StringBuilder("Intercepted outgoing connection to host '").append(host).append("'\n");
+        StringBuilder sb = new StringBuilder("Intercepted outgoing connection to host ").append(host).append("\n");
 
         // print stacktrace
         if (this.includeTraces) {

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -22,8 +22,7 @@ public abstract class AbstractEventLogger implements EventLogger {
 
         StringBuilder sb = new StringBuilder("Intercepted outgoing connection to host ").append(host);
         String origHost = event.getOriginalHost();
-        if (origHost != null) { // original host not available since this is logged before eligibility is
-                                // checked
+        if (origHost != null) {
             sb.append(" (").append(origHost).append(")");
         }
         sb.append("\n");

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -46,6 +46,12 @@ public abstract class AbstractEventLogger implements EventLogger {
 
     @Override
     public void logBlock(InterceptEvent event) {
-        getLogger().info("Blocked connection to host '" + event.getHost() + "'");
+        StringBuilder sb = new StringBuilder("Blocked connection to host ");
+        sb.append(event.getHost());
+        String origHost = event.getOriginalHost();
+        if (origHost != null) {
+            sb.append(" (").append(origHost).append(")");
+        }
+        getLogger().info(sb.toString());
     }
 }

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -28,7 +28,9 @@ public abstract class AbstractEventLogger implements EventLogger {
             for (StackTraceElement element : map.keySet()) {
                 sb.append("\tat ").append(element);
                 JavaPlugin providingPlugin = map.get(element);
-                sb.append(" [").append(providingPlugin == null ? "N/A" : providingPlugin.getName()).append(']');
+                if (providingPlugin != null) {
+                    sb.append(" [").append(providingPlugin.getName()).append(']');
+                }
                 sb.append("\n");
             }
         }

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -4,6 +4,7 @@ import me.lucko.networkinterceptor.InterceptEvent;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.Map;
 import java.util.logging.Logger;
 
 public abstract class AbstractEventLogger implements EventLogger {
@@ -18,38 +19,17 @@ public abstract class AbstractEventLogger implements EventLogger {
     @Override
     public void logAttempt(InterceptEvent event) {
         String host = event.getHost();
-        StackTraceElement[] stackTrace = event.getStackTrace();
 
         StringBuilder sb = new StringBuilder("Intercepted outgoing connection to host '").append(host).append("'\n");
 
         // print stacktrace
         if (this.includeTraces) {
-            boolean shouldPrint = false;
-            for (StackTraceElement element : stackTrace) {
-                if (!shouldPrint) {
-                    boolean isInternal = element.getClassName().startsWith("me.lucko.networkinterceptor") ||
-                            element.getClassName().startsWith("java.net") ||
-                            element.getClassName().startsWith("java.security") ||
-                            element.getClassName().startsWith("sun.net") ||
-                            element.getClassName().startsWith("sun.security.ssl");
-
-                    if (!isInternal) {
-                        shouldPrint = true;
-                    }
-                }
-
-                if (shouldPrint) {
-                    sb.append("\tat ").append(element);
-                    try {
-                        // append the name of the plugin
-                        Class<?> clazz = Class.forName(element.getClassName());
-                        JavaPlugin providingPlugin = JavaPlugin.getProvidingPlugin(clazz);
-                        sb.append(" [").append(providingPlugin.getName()).append(']');
-                    } catch (Exception e) {
-                        // ignore
-                    }
-                    sb.append("\n");
-                }
+            Map<StackTraceElement, JavaPlugin> map = event.getNonInternalStackTraceWithPlugins();
+            for (StackTraceElement element : map.keySet()) {
+                sb.append("\tat ").append(element);
+                JavaPlugin providingPlugin = map.get(element);
+                sb.append(" [").append(providingPlugin == null ? "N/A" : providingPlugin.getName()).append(']');
+                sb.append("\n");
             }
         }
 

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -20,7 +20,12 @@ public abstract class AbstractEventLogger implements EventLogger {
     public void logAttempt(InterceptEvent event) {
         String host = event.getHost();
 
-        StringBuilder sb = new StringBuilder("Intercepted outgoing connection to host ").append(host).append("\n");
+        StringBuilder sb = new StringBuilder("Intercepted outgoing connection to host ").append(host);
+        String origHost = event.getOriginalHost();
+        if (origHost != null) {
+            sb.append(" (").append(origHost).append(")");
+        }
+        sb.append("\n");
 
         // print stacktrace
         if (this.includeTraces) {

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -44,7 +44,7 @@ public abstract class AbstractEventLogger implements EventLogger {
                         // append the name of the plugin
                         Class<?> clazz = Class.forName(element.getClassName());
                         JavaPlugin providingPlugin = JavaPlugin.getProvidingPlugin(clazz);
-                        sb.append(" [").append(providingPlugin.getName()).append("]");
+                        sb.append(" [").append(providingPlugin.getName()).append(']');
                     } catch (Exception e) {
                         // ignore
                     }

--- a/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/AbstractEventLogger.java
@@ -42,7 +42,7 @@ public abstract class AbstractEventLogger implements EventLogger {
                     sb.append("\tat ").append(element);
                     try {
                         // append the name of the plugin
-                        Class clazz = Class.forName(element.getClassName());
+                        Class<?> clazz = Class.forName(element.getClassName());
                         JavaPlugin providingPlugin = JavaPlugin.getProvidingPlugin(clazz);
                         sb.append(" [").append(providingPlugin.getName()).append("]");
                     } catch (Exception e) {

--- a/src/main/java/me/lucko/networkinterceptor/loggers/CompositeLogger.java
+++ b/src/main/java/me/lucko/networkinterceptor/loggers/CompositeLogger.java
@@ -21,7 +21,7 @@ public class CompositeLogger implements EventLogger {
             try {
                 logger.logAttempt(event);
             } catch (Exception e) {
-                e.getStackTrace();
+                e.printStackTrace();
             }
         }
     }
@@ -32,7 +32,7 @@ public class CompositeLogger implements EventLogger {
             try {
                 logger.logBlock(event);
             } catch (Exception e) {
-                e.getStackTrace();
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,6 +20,8 @@ methods:
   - security-manager
   - proxy-selector
 
+# bStats
+bstats-enable: false
 
 # Configures the logging aspect of the plugin
 #

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,6 +43,13 @@ logging:
   # either: 'console', 'file' or 'all'
   mode: console
 
+# Configure whether fully qualified domain names (FQDNs) are mapped to their IP addresses
+# This will allow calls to IP addresses that are the result of a call to a specific FQDN
+# within a certain amount of time of the former.
+mapping:
+  enabled: true
+  # The time (in ms) within which IPs are allowed to pass as per their FQDN permissions
+  timer: 100
 
 # Configures the blocking aspect of the plugin
 #

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,13 +1,8 @@
-# pHD
-#
-# See http://wiki.bukkit.org/Plugin_YAML for a complete list of requirements and options.
-
 name: ${project.name}
 version: ${project.version}
 api-version: 1.13
 main: ${project.groupId}.${project.artifactId}.NetworkInterceptor
 description: ${project.description}
-website: ${website}
 authors: [drives_a_ford, Luck, SlimeDog]
 load: STARTUP
 depend: []
@@ -18,3 +13,9 @@ commands:
     description: Main plugin command
     usage: /<command> reload
     aliases: [ni]
+    permission: networkinterceptor.command.reload
+
+permissions:
+  networkinterceptor.command.reload:
+    description: Allows reloading the config
+    default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,20 @@
+# pHD
+#
+# See http://wiki.bukkit.org/Plugin_YAML for a complete list of requirements and options.
+
 name: ${project.name}
 version: ${project.version}
-main: me.lucko.networkinterceptor.NetworkInterceptor
-author: Luck
+api-version: 1.13
+main: ${project.groupId}.${project.artifactId}.NetworkInterceptor
+description: ${project.description}
+website: ${website}
+authors: [drives_a_ford, Luck, SlimeDog]
 load: STARTUP
+depend: []
+softdepend: []
+
+commands:
+  networkinterceptor:
+    description: Main plugin command
+    usage: /<command> reload
+    aliases: [ni]


### PR DESCRIPTION
This pull request includes the reload command pull request
https://github.com/lucko/NetworkInterceptor/pull/9
(With a small change to clear the interceptors in order not to leak old interceptors).

It also creates the possibility of only specifying a specific FQDN and being able to determine the FQDN of an IP and allowing such connections in certain situations.
The assumption is made that the first connection is made to the FQDN.
Subsequent connections with the same stack trace within a certain (configurable) amount of time will be treated as pointing to the FQDN (so if connections to the FQDN were allowed, the subsequent connections to the IPs are also allowed).

Also appending plugin name to stack traces which can be attributed to a plugin.
The plan is to use this information in order to allow users of the plugin to block or block and/or allow all network connections for specified plugins.