### PR TITLE
Folia compatibility

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ load: STARTUP
 loadbefore: [LuckPerms]
 depend: []
 softdepend: []
+folia-supported: true
 
 commands:
   networkinterceptor:


### PR DESCRIPTION
folia-supported: true

Of course, this PR should not be merged until Folia is actually available for testing and supported. There will be a significant ramp before the major plugins are updated to support Folia.

Since this plugin does not manipulate chunks, operating through the `global region` thread should be relatively simple. An example of how to perform this magic may be found [here](https://github.com/ViaVersion/ViaVersion/blob/master/bukkit/src/main/java/com/viaversion/viaversion/ViaVersionPlugin.java).